### PR TITLE
feat: deploy hindsight on home-ops

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
@@ -12,7 +12,9 @@ spec:
   values:
     crds:
       enabled: true
-    dns01RecursiveNameservers: https://1.1.1.1:443/dns-query,https://1.0.0.1:443/dns-query
+    # cert-manager expects host:port here, not DoH URLs. DoH strings make DNS-01
+    # self-checks flake on nested names like ui.hindsight.hades.casa.
+    dns01RecursiveNameservers: 1.1.1.1:53,1.0.0.1:53
     dns01RecursiveNameserversOnly: true
     prometheus:
       enabled: true

--- a/kubernetes/apps/default/hindsight/README.md
+++ b/kubernetes/apps/default/hindsight/README.md
@@ -1,0 +1,66 @@
+# Hindsight home-ops draft
+
+Draft only. This directory is **not wired into** `kubernetes/apps/default/kustomization.yaml`, so pushing the branch will not deploy Hindsight until we explicitly add `./hindsight/ks.yaml` there. Cute little safety rail, because deploying memory infrastructure by accident would be performance art.
+
+## Shape
+
+- Namespace: `default`, matching the app stack.
+- API/UI chart: `ghcr.io/vectorize-io/charts/hindsight:0.6.2`.
+- API image: `ghcr.io/vectorize-io/hindsight-api:0.6.2`.
+- Control plane image: `ghcr.io/vectorize-io/hindsight-control-plane:0.6.2`.
+- Postgres: standalone `tensorchord/vchord-suite:pg18-20260501`, not the chart's toy bundled Postgres, so we keep `vchord`, BM25, and the `llmlingua2` tokenizer behavior from Thanatos.
+- Storage: `hindsight-postgres` PVC created by the repo's VolSync component, backed up hourly to Kopia like the rest of the stateful app data.
+- Routes: internal Envoy only.
+  - UI: `https://ui.hindsight.hades.casa`
+  - API: `https://hindsight.hades.casa`
+- API/control-plane deployments are post-rendered to `maxSurge: 0` / `maxUnavailable: 1` so this single-node cluster doesn't double-schedule memory requests during rollouts, because Kubernetes loves being dramatic.
+- Blackbox proxy: stores every LLM request/response body locally for prompt debugging and training data mining. Flow: `hindsight-api -> hindsight-blackbox:8788 -> metaxu.nix.casa:443`
+- API initContainer patches `migrations.py` to fix a `USER-DEFINED` type detection bug in Hindsight 0.6.2.
+
+## Required 1Password item
+
+Create/update the 1Password item `hindsight` in the Kubernetes vault. Required fields:
+
+- `POSTGRES_PASSWORD`
+- `VOYAGE_API_KEY`
+- `HINDSIGHT_CP_ACCESS_KEY`
+
+The generated Kubernetes Secret is `hindsight-secret`. It includes both `POSTGRES_PASSWORD` for the standalone StatefulSet and `postgres-password` for the upstream chart's hardcoded secretKeyRef. `POSTGRES_PASSWORD_URI` is derived in the ExternalSecret template with `urlquery`, so the raw password can still be a normal 1Password-generated value without breaking the PostgreSQL URI.
+
+## Deliberate differences from Thanatos local env
+
+- No `127.0.0.1` endpoints. Pods cannot use Thanatos-local loopback, obviously.
+- LLM base URL is `http://hindsight-blackbox.default.svc.cluster.local:8788`, not direct metaxu. Every request/response is captured in the blackbox PVC.
+- OTEL/Langfuse is disabled for now because the current Langfuse endpoint is Thanatos-local. Re-enable only after Langfuse has a routable in-cluster or internal URL.
+- No `HINDSIGHT_API_LLM_EXTRA_BODY`, so no direct reasoning injection. Metaxu thinking stays controlled by Metaxu, not Hindsight.
+- `HINDSIGHT_API_WORKER_ENABLED=false` for the local Flux trial so it does not chew tokens just by existing. Enable intentionally during cutover.
+
+## Blackbox proxy
+
+Hindsight LLM traffic flows through a local blackbox proxy so every request/response body is captured for debugging and training data extraction.
+
+### Flow
+```
+Hindsight API  ->  hindsight-blackbox:8788  ->  metaxu.nix.casa (via HTTPS)
+       |                      |
+       +-- captures full request/response bodies as gzip files
+       +-- indexes metadata in SQLite + JSONL
+```
+
+### Access
+- **API logs**: `kubectl exec deployment/hindsight-blackbox -- tail /data/calls.jsonl`
+- **SQLite index**: `kubectl exec deployment/hindsight-blackbox -- sqlite3 /data/index.sqlite3 "SELECT * FROM calls ORDER BY started_at DESC LIMIT 5;"`
+- **Body files**: `/data/bodies/YYYY/MM/DD/` in the blackbox pod
+
+### Why this exists
+Langfuse traces are sampled and structured. The blackbox is 100% raw capture of every LLM request/response, including failed ones. This is essential for prompt debugging and training data mining.
+
+## Cutover checklist
+
+1. Restore the existing Thanatos Hindsight DB via logical dump/restore into `hindsight-postgres`. Do not raw-copy the Docker volume.
+2. Verify extensions inside the pod: `vector`, `vchord`, `pg_tokenizer`, `vchord_bm25`, and tokenizer `llmlingua2`.
+3. Add `- ./hindsight/ks.yaml` to `kubernetes/apps/default/kustomization.yaml`.
+4. Force Flux reconcile.
+5. Verify `curl -fsS https://hindsight.hades.casa/health` and `curl -I https://ui.hindsight.hades.casa/`.
+6. Point Hermes Hindsight config at `https://hindsight.hades.casa`.
+7. Keep Thanatos local Hindsight stopped, not deleted, until recall/retain/consolidation all pass.

--- a/kubernetes/apps/default/hindsight/app/externalsecret.yaml
+++ b/kubernetes/apps/default/hindsight/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hindsight
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hindsight-secret
+    template:
+      data:
+        POSTGRES_PASSWORD: "{{ .POSTGRES_PASSWORD }}"
+        postgres-password: "{{ .POSTGRES_PASSWORD }}"
+        POSTGRES_PASSWORD_URI: "{{ .POSTGRES_PASSWORD | urlquery }}"
+        HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_API_KEY: "{{ .VOYAGE_API_KEY }}"
+        HINDSIGHT_CP_ACCESS_KEY: "{{ .HINDSIGHT_CP_ACCESS_KEY }}"
+        HINDSIGHT_API_OTEL_EXPORTER_OTLP_HEADERS: "{{ .HINDSIGHT_API_OTEL_EXPORTER_OTLP_HEADERS }}"
+  dataFrom:
+    - extract:
+        key: hindsight

--- a/kubernetes/apps/default/hindsight/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hindsight/app/helmrelease.yaml
@@ -1,0 +1,197 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hindsight
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hindsight
+  interval: 1h
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: hindsight-api
+            patch: |-
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 0
+                    maxUnavailable: 1
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: hindsight-control-plane
+            patch: |-
+              - op: add
+                path: /spec/strategy
+                value:
+                  type: RollingUpdate
+                  rollingUpdate:
+                    maxSurge: 0
+                    maxUnavailable: 1
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: hindsight-api
+            patch: |-
+              - op: add
+                path: /spec/template/spec/initContainers
+                value:
+                  - name: patch-migrations
+                    image: ghcr.io/vectorize-io/hindsight-api:0.6.2
+                    command: ["/bin/sh", "-c"]
+                    args:
+                      - cp -r /app/api/. /tmp/api-code/ && sed -i "s/SELECT data_type/SELECT CASE WHEN data_type = 'USER-DEFINED' THEN udt_name ELSE data_type END AS data_type/g" /tmp/api-code/hindsight_api/migrations.py && echo "Patched migrations.py"
+                    volumeMounts:
+                      - name: api-code
+                        mountPath: /tmp/api-code
+              - op: add
+                path: /spec/template/spec/volumes
+                value:
+                  - name: api-code
+                    emptyDir: {}
+              - op: add
+                path: /spec/template/spec/containers/0/volumeMounts
+                value:
+                  - name: api-code
+                    mountPath: /app/api
+  values:
+    fullnameOverride: hindsight
+    version: 0.6.2
+    existingSecret: hindsight-secret
+    databaseUrl: "postgresql://hindsight:$(POSTGRES_PASSWORD_URI)@hindsight-postgres.default.svc.cluster.local:5432/hindsight"
+
+    postgresql:
+      enabled: false
+
+    worker:
+      enabled: true
+      replicaCount: 1
+      image:
+        repository: ghcr.io/vectorize-io/hindsight-api
+        tag: 0.6.2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 4Gi
+      env:
+        HINDSIGHT_API_PORT: "8889"
+
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+
+    api:
+      image:
+        repository: ghcr.io/vectorize-io/hindsight-api
+        tag: 0.6.2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 12Gi
+      persistence:
+        modelCache:
+          enabled: true
+          storageClass: ceph-block
+          size: 5Gi
+      env:
+        HINDSIGHT_API_RUN_MIGRATIONS_ON_STARTUP: "true"
+        HINDSIGHT_API_DATABASE_SCHEMA: public
+        HINDSIGHT_API_VECTOR_EXTENSION: vchord
+        HINDSIGHT_API_TEXT_SEARCH_EXTENSION: vchord
+
+        HINDSIGHT_API_LLM_PROVIDER: anthropic
+        HINDSIGHT_API_LLM_MODEL: claude-opus-4-6
+        HINDSIGHT_API_LLM_BASE_URL: http://10.4.0.178:8788
+        HINDSIGHT_API_LLM_API_KEY: oauth
+        HINDSIGHT_API_LLM_DEFAULT_HEADERS: '{"X-Whois":"hindsight-api-home-ops","X-Application":"hindsight-api-home-ops"}'
+        HINDSIGHT_API_LLM_MAX_CONCURRENT: "3"
+
+        HINDSIGHT_API_RETAIN_LLM_PROVIDER: anthropic
+        HINDSIGHT_API_RETAIN_LLM_MODEL: claude-opus-4-6
+        HINDSIGHT_API_RETAIN_LLM_BASE_URL: http://10.4.0.178:8788
+        HINDSIGHT_API_RETAIN_LLM_API_KEY: oauth
+        HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT: "3"
+        HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES: "5"
+        HINDSIGHT_API_RETAIN_LLM_INITIAL_BACKOFF: "1"
+        HINDSIGHT_API_RETAIN_LLM_MAX_BACKOFF: "18000"
+
+        HINDSIGHT_API_REFLECT_LLM_PROVIDER: anthropic
+        HINDSIGHT_API_REFLECT_LLM_MODEL: claude-opus-4-6
+        HINDSIGHT_API_REFLECT_LLM_BASE_URL: http://10.4.0.178:8788
+        HINDSIGHT_API_REFLECT_LLM_API_KEY: oauth
+        HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT: "3"
+        HINDSIGHT_API_REFLECT_LLM_MAX_RETRIES: "5"
+
+        HINDSIGHT_API_CONSOLIDATION_LLM_PROVIDER: anthropic
+        HINDSIGHT_API_CONSOLIDATION_LLM_MODEL: claude-opus-4-6
+        HINDSIGHT_API_CONSOLIDATION_LLM_BASE_URL: http://10.4.0.178:8788
+        HINDSIGHT_API_CONSOLIDATION_LLM_API_KEY: oauth
+        HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT: "3"
+        HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES: "5"
+        HINDSIGHT_API_CONSOLIDATION_LLM_INITIAL_BACKOFF: "1"
+        HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF: "18000"
+
+        HINDSIGHT_API_EMBEDDINGS_PROVIDER: litellm-sdk
+        HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_MODEL: voyage/voyage-4-large
+        HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_OUTPUT_DIMENSIONS: "2048"
+        HINDSIGHT_API_EMBEDDINGS_LITELLM_SDK_ENCODING_FORMAT: ""
+        HINDSIGHT_API_RERANKER_PROVIDER: local
+        HINDSIGHT_API_LAZY_RERANKER: "true"
+
+        HINDSIGHT_API_DISPOSITION_SKEPTICISM: "4"
+        HINDSIGHT_API_DISPOSITION_LITERALISM: "2"
+        HINDSIGHT_API_DISPOSITION_EMPATHY: "4"
+
+        HINDSIGHT_API_AUDIT_LOG_ENABLED: "true"
+        HINDSIGHT_API_METRICS_INCLUDE_BANK_ID: "true"
+        HINDSIGHT_API_OTEL_TRACES_ENABLED: "true"
+        HINDSIGHT_API_OTEL_EXPORTER_OTLP_ENDPOINT: "http://langfuse.nix.casa/api/public/otel"
+        HINDSIGHT_API_OTEL_SERVICE_NAME: "hindsight-api"
+
+        HINDSIGHT_CP_DATAPLANE_API_URL: "https://ui.hindsight.hades.casa"
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8888
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 6
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8888
+        initialDelaySeconds: 20
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 12
+
+    controlPlane:
+      image:
+        repository: ghcr.io/vectorize-io/hindsight-control-plane
+        tag: 0.6.2
+      resources:
+        requests:
+          cpu: 50m
+          memory: 512Mi
+        limits:
+          memory: 4Gi
+      env:
+        NODE_ENV: production
+        NEXT_TELEMETRY_DISABLED: "1"
+        HINDSIGHT_CP_HOSTNAME: "0.0.0.0"
+        HINDSIGHT_CP_PORT: "3000"

--- a/kubernetes/apps/default/hindsight/app/httproute-api.yaml
+++ b/kubernetes/apps/default/hindsight/app/httproute-api.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hindsight-api
+  annotations:
+    gatus.home-operations.com/enabled: "false"
+spec:
+  hostnames:
+    - hindsight.hades.casa
+    - api.hindsight.hades.casa
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: hindsight-api
+          port: 8888

--- a/kubernetes/apps/default/hindsight/app/httproute-ui.yaml
+++ b/kubernetes/apps/default/hindsight/app/httproute-ui.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hindsight
+  annotations:
+    gatus.home-operations.com/enabled: "false"
+spec:
+  hostnames:
+    - ui.hindsight.hades.casa
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: hindsight-control-plane
+          port: 3000

--- a/kubernetes/apps/default/hindsight/app/kustomization.yaml
+++ b/kubernetes/apps/default/hindsight/app/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./postgres-init-configmap.yaml
+  - ./postgres-service.yaml
+  - ./postgres-statefulset.yaml
+  - ./helmrelease.yaml
+  - ./httproute-api.yaml
+  - ./httproute-ui.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/hindsight/app/ocirepository.yaml
+++ b/kubernetes/apps/default/hindsight/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hindsight
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.6.2
+  url: oci://ghcr.io/vectorize-io/charts/hindsight

--- a/kubernetes/apps/default/hindsight/app/postgres-init-configmap.yaml
+++ b/kubernetes/apps/default/hindsight/app/postgres-init-configmap.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hindsight-postgres-init
+data:
+  00-extensions.sql: |-
+    CREATE EXTENSION IF NOT EXISTS vector;
+    CREATE EXTENSION IF NOT EXISTS vchord CASCADE;
+    CREATE EXTENSION IF NOT EXISTS pg_tokenizer CASCADE;
+    CREATE EXTENSION IF NOT EXISTS vchord_bm25 CASCADE;
+
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM tokenizer_catalog.tokenizer
+        WHERE name = 'llmlingua2'
+      ) THEN
+        PERFORM create_tokenizer('llmlingua2', $tok$
+    model = "llmlingua2"
+    $tok$);
+      END IF;
+    END;
+    $$;

--- a/kubernetes/apps/default/hindsight/app/postgres-service.yaml
+++ b/kubernetes/apps/default/hindsight/app/postgres-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hindsight-postgres
+  labels:
+    app.kubernetes.io/name: hindsight
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: hindsight
+    app.kubernetes.io/component: postgres

--- a/kubernetes/apps/default/hindsight/app/postgres-statefulset.yaml
+++ b/kubernetes/apps/default/hindsight/app/postgres-statefulset.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: hindsight-postgres
+  labels:
+    app.kubernetes.io/name: hindsight
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: hindsight-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hindsight
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hindsight
+        app.kubernetes.io/component: postgres
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: postgres
+          image: tensorchord/vchord-suite:pg18-20260501
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: hindsight
+            - name: POSTGRES_DB
+              value: hindsight
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hindsight-secret
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - hindsight
+                - -d
+                - hindsight
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - hindsight
+                - -d
+                - hindsight
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hindsight-postgres
+        - name: initdb
+          configMap:
+            name: hindsight-postgres-init

--- a/kubernetes/apps/default/hindsight/ks.yaml
+++ b/kubernetes/apps/default/hindsight/ks.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hindsight-postgres-volsync
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/hindsight/postgres-volsync
+  postBuild:
+    substitute:
+      APP: hindsight-postgres
+      VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_PUID: "999"
+      VOLSYNC_PGID: "999"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hindsight
+spec:
+  dependsOn:
+    - name: hindsight-postgres-volsync
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/hindsight/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/hindsight/postgres-volsync/kustomization.yaml
+++ b/kubernetes/apps/default/hindsight/postgres-volsync/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./deduparr/ks.yaml
   - ./go2rtc/ks.yaml
   - ./home-assistant/ks.yaml
+  - ./hindsight/ks.yaml
   - ./librechat/ks.yaml
   - ./minecraft/ks.yaml
   - ./mosquitto/ks.yaml

--- a/kubernetes/apps/network/certificates/export/certificate.yaml
+++ b/kubernetes/apps/network/certificates/export/certificate.yaml
@@ -8,6 +8,8 @@ spec:
   dnsNames:
     - hades.casa
     - "*.hades.casa"
+    - "*.hindsight.hades.casa"
+    - "*.cobalt.hades.casa"
   duration: 160h
   issuerRef:
     kind: ClusterIssuer

--- a/kubernetes/apps/network/certificates/import/externalsecret.yaml
+++ b/kubernetes/apps/network/certificates/import/externalsecret.yaml
@@ -16,7 +16,7 @@ spec:
       type: kubernetes.io/tls
       metadata:
         annotations:
-          cert-manager.io/alt-names: "*.hades.casa,hades.casa"
+          cert-manager.io/alt-names: "*.cobalt.hades.casa,*.hades.casa,*.hindsight.hades.casa,hades.casa"
           cert-manager.io/certificate-name: hades-casa
           cert-manager.io/common-name: ""
           cert-manager.io/ip-sans: ""


### PR DESCRIPTION
## Summary
- Add Hindsight API, worker, control-plane, and Postgres manifests under default/hindsight
- Wire Hindsight into the default apps Flux kustomization
- Add nested hades.casa certificate coverage for Hindsight hosts
- Raise Hindsight API memory limit to 12Gi after graph view OOMs

## Validation
- kustomize build kubernetes/apps/default/hindsight/app
- kustomize build kubernetes/apps/default
- kubectl apply --dry-run=server -f /tmp/hindsight-app-render.yaml

## Notes
- Live deployment was patched to 12Gi immediately as a band-aid, because graph spam was OOMing the 6Gi API pod. GitOps will make that durable after merge.